### PR TITLE
Add download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Free Creative Commons audio assets for use in Spoke and Hubs.
 
+# Download
+
+This repository uses [Git LFS](https://git-lfs.com/).
+
+If you just want the files to use, please [download them from here](https://drive.google.com/drive/folders/10uNFTAn3U-QWaSDvB4bYOA1cLBzoVlcT?usp=sharing).
+
+**Contributors:**
+If you want to contribute to the repository, you will need to have Git LFS installed before cloning the repository (don't forget to run `git lfs install` once you've installed it).
+
 # License
 
 All audio assets in this repository are licensed with [CC-BY 2.0](https://creativecommons.org/licenses/by/2.0/).


### PR DESCRIPTION
Add download section to the readme.
Add link to downloadable assets on the Hubs Foundation's Google Drive.
Add note for contributors that they will need to install Git LFS in order to clone the repository.

GitHub's LFS downloads are expensive, so a copy of the files has been provided on the Hubs Foundation's Google Drive for people to download to help save bandwidth.